### PR TITLE
Set up prettier and ESLint 

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,7 +1,6 @@
 import { FlatCompat } from "@eslint/eslintrc";
 
 const compat = new FlatCompat({
-  // import.meta.dirname is available after Node.js v20.11.0
   baseDirectory: import.meta.dirname,
 });
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,12 +1,17 @@
 import { FlatCompat } from "@eslint/eslintrc";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 const compat = new FlatCompat({
-  baseDirectory: import.meta.dirname,
+  baseDirectory: __dirname,
 });
 
 const eslintConfig = [
   ...compat.config({
-    extends: ["next", "prettier"],
+    extends: ["next/core-web-vitals", "next/typescript", "prettier"],
   }),
   {
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,16 +1,14 @@
-import { dirname } from "path";
-import { fileURLToPath } from "url";
 import { FlatCompat } from "@eslint/eslintrc";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
 const compat = new FlatCompat({
-  baseDirectory: __dirname,
+  // import.meta.dirname is available after Node.js v20.11.0
+  baseDirectory: import.meta.dirname,
 });
 
 const eslintConfig = [
-  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  ...compat.config({
+    extends: ["next", "prettier"],
+  }),
   {
     rules: {
       "@next/next/no-img-element": "off",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  eslint: {
+    // Warning: This allows production builds to successfully complete even if
+    // your project has ESLint errors.
+    ignoreDuringBuilds: true,
+  },
 };
 
 export default nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "15.1.7",
+        "eslint-config-prettier": "^10.1.8",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "typescript": "^5"
@@ -2292,6 +2293,22 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "15.1.7",
+    "eslint-config-prettier": "^10.1.8",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "typescript": "^5"


### PR DESCRIPTION
# Highlight Lint Errors

<img width="495" height="181" alt="image" src="https://github.com/user-attachments/assets/c87c0702-258d-4540-829a-4d2c3f40aff7" />

# The code that does this, because I feel like I'll need this again 

From #7, commit [347fec1](https://github.com/kohrachel/kohrachel.com/pull/7/commits/347fec1163bbdc043f47b1535639646eab8c9d79) in `~.vscode/settings.json`

This sets up the editor to highlight ESLint errors and warnings in the IDE rather than in catching them in the production build. Which is totally not what I had been doing previously 

<img width="514" height="270" alt="image" src="https://github.com/user-attachments/assets/51142372-14ca-4acd-bffa-9aa953cbfe75" />

## Disable lint checks in prod builds

Since the errors (should) get caught in dev now, I'm going to try to minimize the number of failed deployments due to lint errors by disabling linting in prod environments 

<img width="707" height="321" alt="image" src="https://github.com/user-attachments/assets/0a3b853e-2f7e-4c2e-82f7-b82256e6da62" />

Closes #4 